### PR TITLE
update makefile to use python3 instead of python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ demo-ui:
 		 ./$@
 
 secrets/db%: secrets/configuration.json
-	@python secrets/parseConf.py $^ db$* $@
+	@python3 secrets/parseConf.py $^ db$* $@
 
 deploy: init secrets/dbUser secrets/dbPass
 	docker stack deploy \


### PR DESCRIPTION
python is not installed by default on ubuntu, but python3 is. This patch updates the makefile to use python3 